### PR TITLE
Add a moira/light system without the Osicat dependency

### DIFF
--- a/moira.asd
+++ b/moira.asd
@@ -1,15 +1,14 @@
 ;;;; moira.asd
 
-(asdf:defsystem #:moira
-  :description "Monitor and restart background threads."
+(asdf:defsystem #:moira/light
+  :description "Moira base system without the Osicat dependency, hence without thread id support on Linux."
   :author "Paul M. Rodriguez <pmr@ruricolist.com>"
   :license "MIT"
   :depends-on (#:alexandria
                #:serapeum
                #:trivial-features
                #:bordeaux-threads
-               #:trivial-garbage
-               #:osicat)
+               #:trivial-garbage)
   :components ((:file "package")
                (:file "types" :depends-on ("package"))
                (:file "thread-ids" :depends-on ("package"))
@@ -17,3 +16,10 @@
                (:file "monitor" :depends-on ("package" "types"))
                (:file "spawn" :depends-on ("package" "thread-ids" "moira"))))
 
+(asdf:defsystem #:moira
+  :description "Monitor and restart background threads."
+  :author "Paul M. Rodriguez <pmr@ruricolist.com>"
+  :license "MIT"
+  :depends-on (#:moira/light
+               #:osicat)
+  :components ((:file "thread-ids-linux")))

--- a/package.lisp
+++ b/package.lisp
@@ -5,8 +5,7 @@
   #+sbcl
   (:local-nicknames
    (#:bt #:bordeaux-threads)
-   (#:tg #:trivial-garbage)
-   (#:nix #:osicat-posix))
+   (#:tg #:trivial-garbage))
   (:export #:thread-id
            #:save-current-thread-id
            #:make-thread-saving-id

--- a/thread-ids-linux.lisp
+++ b/thread-ids-linux.lisp
@@ -1,0 +1,13 @@
+(in-package #:moira)
+
+#+linux
+(macrolet ((with-thread-id-lock ((&key) &body body)
+             #+ccl `(progn ,@body)      ;Lock-free hash tables!
+             #-ccl `(synchronized ('*thread-ids*)
+                      ,@body)))
+
+  (defun save-current-thread-id ()
+    (with-thread-id-lock ()
+      (let ((thread (bt:current-thread))
+            (tid (osicat-posix:gettid)))
+        (setf (gethash thread *thread-ids*) tid)))))

--- a/thread-ids.lisp
+++ b/thread-ids.lisp
@@ -24,10 +24,8 @@
        *thread-ids*)))
 
   (defun save-current-thread-id ()
-    (with-thread-id-lock ()
-      (let ((thread (bt:current-thread))
-            (tid (nix:gettid)))
-        (setf (gethash thread *thread-ids*) tid)))))
+    ;; Overwritten in thread-ids-linux.lisp
+    (values)))
 
 #-linux
 (progn

--- a/thread-ids.lisp
+++ b/thread-ids.lisp
@@ -23,6 +23,8 @@
              k)))
        *thread-ids*)))
 
+  ;; Ensure the later redefinition for linux to be seen.'
+  (declaim (notinline save-current-thread-id))
   (defun save-current-thread-id ()
     ;; Overwritten in thread-ids-linux.lisp
     (values)))


### PR DESCRIPTION
I am trying it this way so that this change doesn't break backwards compatibility for existing users, quickloading "moira" brings osicat and tid support just as before, but users like me can load "moira/light".

Tested: quickload moira/light, check that moira:save-current-thread-id brings me to "thread-ids.lisp", returning `(values)`, then quickload moira and check that the function brings me to "thread-ids-linux.lisp". I don't see any warning in doing that (SBCL 2.0.1-debian). The macrolet `macrolet ((with-thread-id-lock …` is copy-pasted.

I could have added a PLN with `uiop:add-package-local-nickname` but for one function call this might have more drawbacks than benefits (there are lisps with an old ASDF without PLN support by default…).

Thanks!